### PR TITLE
Feature Request: add events to allow manipulation of settings

### DIFF
--- a/Classes/Event/AfterSettingsAreProcessedEvent.php
+++ b/Classes/Event/AfterSettingsAreProcessedEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mediadreams\MdSaml\Event;
+
+final class AfterSettingsAreProcessedEvent
+{
+    public function __construct(
+        private readonly string $loginType,
+        private array $settings
+    ){}
+
+    public function getLoginType(): string
+    {
+        return $this->loginType;
+    }
+
+    public function getSettings(): array
+    {
+        return $this->settings;
+    }
+
+    public function setSettings(array $settings): void
+    {
+        $this->settings = $settings;
+    }
+}

--- a/Classes/Event/BeforeSettingsAreProcessedEvent.php
+++ b/Classes/Event/BeforeSettingsAreProcessedEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mediadreams\MdSaml\Event;
+
+final class BeforeSettingsAreProcessedEvent
+{
+    public function __construct(
+        private readonly string $loginType,
+        private array $settings
+    ){}
+
+    public function getLoginType(): string
+    {
+        return $this->loginType;
+    }
+
+    public function getSettings(): array
+    {
+        return $this->settings;
+    }
+
+    public function setSettings(array $settings): void
+    {
+        $this->settings = $settings;
+    }
+}


### PR DESCRIPTION
At the moment, settings can only be set using typoscript. In some situations it could be usefull if there would be an option to modify the settings dynamically.

Example: If you want to change the baseUrl according to the environment (development, staging, production) or if you want to use YAML for configuration instead of typoscript.

This pull request add events after and before settings are processed.

I will add further pull requests in the next days. The first pull request will add an event-listener to support YAML configuration. The second pull request will add an event-listener to set url of the service provider dyamically, based on the trustedHostsPattern.

By splitting the features in different pull request, you can decide which of the feature you want to integrate.