### PR TITLE
[TASK] Handle unset 'login-provider' in SamlAuthService

### DIFF
--- a/Classes/Authentication/SamlAuthService.php
+++ b/Classes/Authentication/SamlAuthService.php
@@ -115,7 +115,7 @@ class SamlAuthService extends AbstractAuthenticationService
             return true;
         }
 
-        return $_REQUEST['login-provider'] === 'md_saml'
+        return ($_REQUEST['login-provider'] ?? '') === 'md_saml'
             && ($this->pObj->loginType === 'BE' || $this->pObj->loginType === 'FE')
             && isset($this->login['status'])
             && $this->login['status'] === 'login';


### PR DESCRIPTION
Added null coalescing operator to handle cases where 'login-provider' is not set in the request.

 fixes https://github.com/cdaecke/md_saml/issues/33