### PR TITLE
Non-breaking empty configuration

### DIFF
--- a/Classes/Authentication/SamlAuthService.php
+++ b/Classes/Authentication/SamlAuthService.php
@@ -220,6 +220,10 @@ class SamlAuthService extends AbstractAuthenticationService
         $loginType = $this->pObj->loginType;
 
         $extSettings = $this->settingsService->getSettings($loginType);
+        if (!$extSettings) {
+            $this->logger->error('No TypoScript plugin.tx_mdsaml.settings configured. Perhaps you did not include the md_saml static include.');
+            return false;
+        }
 
         if (
             isset($_REQUEST['acs'])

--- a/Classes/Error/ForbiddenHandling.php
+++ b/Classes/Error/ForbiddenHandling.php
@@ -38,9 +38,11 @@ class ForbiddenHandling implements PageErrorHandlerInterface
     ): ResponseInterface {
         $loginType = 'FE';
         $extSettings = $this->settingsService->getSettings($loginType);
-        $auth = new Auth($extSettings['saml']);
-        $auth->login();
-        // above code redirects
+        if ($extSettings) {
+            $auth = new Auth($extSettings['saml']);
+            $auth->login();
+        } 
+        // if successful, above code redirects
         return new RedirectResponse('/', 403);
     }
 }

--- a/Classes/EventListener/SamlAfterUserLoggedOutEventListener.php
+++ b/Classes/EventListener/SamlAfterUserLoggedOutEventListener.php
@@ -21,8 +21,10 @@ final class SamlAfterUserLoggedOutEventListener
         $settingsService = GeneralUtility::makeInstance(SettingsService::class);
         if ($settingsService->getInCharge()) {
             $extSettings = $settingsService->getSettings($event->getUser()->loginType);
-            $auth = new Auth($extSettings['saml']);
-            $auth->logout();
+            if ($extSettings) {
+                $auth = new Auth($extSettings['saml']);
+                $auth->logout();
+            }
         }
     }
 }

--- a/Classes/Service/SettingsService.php
+++ b/Classes/Service/SettingsService.php
@@ -16,6 +16,7 @@ namespace Mediadreams\MdSaml\Service;
 use Mediadreams\MdSaml\Event\AfterSettingsAreProcessedEvent;
 use Mediadreams\MdSaml\Event\BeforeSettingsAreProcessedEvent;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Site\Entity\Site;
 use TYPO3\CMS\Core\Site\SiteFinder;
@@ -36,7 +37,7 @@ class SettingsService implements SingletonInterface
 
     protected EventDispatcherInterface $eventDispatcher;
 
-    public function __construct()
+    public function __construct(private readonly LoggerInterface $logger)
     {
         $this->eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
     }
@@ -91,8 +92,9 @@ class SettingsService implements SingletonInterface
                 );
             }
 
-            if ((is_countable($this->extSettings) ? count($this->extSettings) : 0) === 0) {
-                throw new \RuntimeException('The TypoScript of ext:md_saml was not loaded.', 1648151884);
+            if (!$this->extSettings) {
+                $this->logger->error('No TypoScript plugin.tx_mdsaml.settings configured. Perhaps you did not include the md_saml static include.');
+                return [];
             }
         }
 


### PR DESCRIPTION
Only continue if settings is initialized, log ERROR if not.

Otherwise it was not possible to login, unless md_saml static include is include.

Resolves: #39