### PR TITLE
Update rector rules for typo3 v12+php8.1

### DIFF
--- a/Classes/Authentication/SamlAuthService.php
+++ b/Classes/Authentication/SamlAuthService.php
@@ -61,7 +61,7 @@ class SamlAuthService extends AbstractAuthenticationService
 
     protected SettingsService $settingsService;
 
-    private EventDispatcherInterface $eventDispatcher;
+    private readonly EventDispatcherInterface $eventDispatcher;
 
     public function __construct()
     {
@@ -260,7 +260,7 @@ class SamlAuthService extends AbstractAuthenticationService
                 if ($auth->getSettings()->isDebugActive()) {
                     echo '<h1>SAML error</h1>';
                     echo '<p>' . implode(', ', $errors) . '</p>';
-                    echo '<p>' . htmlentities($auth->getLastErrorReason(), ENT_QUOTES | ENT_HTML5) . '</p>';
+                    echo '<p>' . htmlentities((string) $auth->getLastErrorReason(), ENT_QUOTES | ENT_HTML5) . '</p>';
                     static::getLogger()->debug(
                         'SAML authentification: ' . __METHOD__ . ' EXIT in line ' . __LINE__
                     );
@@ -272,7 +272,7 @@ class SamlAuthService extends AbstractAuthenticationService
                     // redirection confirm the value of $_POST['RelayState'] is a // trusted URL.
                     //$auth->redirectTo($_POST['RelayState']);
                     $url = GeneralUtility::getIndpEnv('TYPO3_SITE_URL')
-                        . TYPO3_mainDir
+                        . \TYPO3_MAINDIR
                         . '?loginProvider=1648123062&error=1';
                     throw new PropagateResponseException(new RedirectResponse($url, 303), 1706128564);
                 }
@@ -356,8 +356,8 @@ class SamlAuthService extends AbstractAuthenticationService
 
         // Add default values from TypoScript settings to user array
         foreach ($extSettings[$this->authInfo['db_user']['table']]['databaseDefaults'] as $key => $val) {
-            $key = trim($key);
-            $val = trim($val);
+            $key = trim((string) $key);
+            $val = trim((string) $val);
 
             if ($val !== '') {
                 $userArr[$key] = $val;

--- a/Classes/Middleware/AcsSamlMiddleware.php
+++ b/Classes/Middleware/AcsSamlMiddleware.php
@@ -27,20 +27,14 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 class AcsSamlMiddleware implements MiddlewareInterface
 {
-    protected SettingsService $settingsService;
-
-    private ResponseFactoryInterface $responseFactory;
-
     /**
      * SamlMiddleware constructor
      *
      * @param ResponseFactoryInterface $responseFactory
      * @param SettingsService $settingsService
      */
-    public function __construct(ResponseFactoryInterface $responseFactory, SettingsService $settingsService)
+    public function __construct(private readonly ResponseFactoryInterface $responseFactory, protected SettingsService $settingsService)
     {
-        $this->responseFactory = $responseFactory;
-        $this->settingsService = $settingsService;
     }
 
     /**

--- a/Classes/Middleware/SamlMiddleware.php
+++ b/Classes/Middleware/SamlMiddleware.php
@@ -27,20 +27,14 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 class SamlMiddleware implements MiddlewareInterface
 {
-    protected SettingsService $settingsService;
-
-    private ResponseFactoryInterface $responseFactory;
-
     /**
      * SamlMiddleware constructor
      *
      * @param ResponseFactoryInterface $responseFactory
      * @param SettingsService $settingsService
      */
-    public function __construct(ResponseFactoryInterface $responseFactory, SettingsService $settingsService)
+    public function __construct(private readonly ResponseFactoryInterface $responseFactory, protected SettingsService $settingsService)
     {
-        $this->responseFactory = $responseFactory;
-        $this->settingsService = $settingsService;
     }
 
     /**

--- a/Classes/Middleware/SlsSamlMiddleware.php
+++ b/Classes/Middleware/SlsSamlMiddleware.php
@@ -30,7 +30,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class SlsSamlMiddleware implements MiddlewareInterface
 {
-    protected SettingsService $settingsService;
+
     protected string $context = '';
 
     /**
@@ -38,9 +38,8 @@ class SlsSamlMiddleware implements MiddlewareInterface
      *
      * @param SettingsService $settingsService
      */
-    public function __construct(SettingsService $settingsService)
+    public function __construct(protected SettingsService $settingsService)
     {
-        $this->settingsService = $settingsService;
     }
 
     /**
@@ -65,7 +64,7 @@ class SlsSamlMiddleware implements MiddlewareInterface
 
             if (!empty($errors)) {
                 $logger = GeneralUtility::makeInstance(LogManager::class)
-                    ->getLogger(__CLASS__);
+                    ->getLogger(self::class);
 
                 $logger->log(
                     LogLevel::ERROR,

--- a/Classes/Service/SettingsService.php
+++ b/Classes/Service/SettingsService.php
@@ -129,7 +129,7 @@ class SettingsService implements SingletonInterface
         $template->runThroughTemplates($rootline, 0);
         $template->generateConfig();
 
-        $typoScriptSetup = $template->setup;
+        $typoScriptSetup = $GLOBALS['TYPO3_REQUEST']->getAttribute('frontend.typoscript')->getSetupArray();
 
         return GeneralUtility::removeDotsFromTS($typoScriptSetup);
     }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"source": "https://github.com/cdaecke/md_saml"
 	},
 	"require": {
-		"php": ">=7.4",
+		"php": ">=8.1",
 		"onelogin/php-saml": "^4.0",
 		"typo3/cms-backend": "^12.4",
 		"typo3/cms-core": "^12.4"
@@ -33,9 +33,10 @@
 		"phpstan/extension-installer": "^1.3.1",
 		"phpstan/phpstan": "^1.10.56",
 		"phpstan/phpstan-strict-rules": "^1.5.2",
+		"rector/rector": "^1.2",
 		"saschaegerer/phpstan-typo3": "^1.9.1",
 		"squizlabs/php_codesniffer": "^3.8.1",
-		"ssch/typo3-rector": "^1.3",
+		"ssch/typo3-rector": "^2.6",
 		"tomasvotruba/type-coverage": "^0.2.1",
 		"typo3/cms-fluid": "^12.4",
 		"typo3/coding-standards": "^0.6.1"

--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Core\ValueObject\PhpVersion;
+use Rector\ValueObject\PhpVersion;
 use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
 use Rector\PostRector\Rector\NameImportingPostRector;
 use Rector\Set\ValueObject\DowngradeLevelSetList;
@@ -13,11 +13,21 @@ use Rector\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector;
 use Ssch\TYPO3Rector\Configuration\Typo3Option;
 use Ssch\TYPO3Rector\FileProcessor\Composer\Rector\ExtensionComposerRector;
 use Ssch\TYPO3Rector\FileProcessor\Composer\Rector\RemoveCmsPackageDirFromExtraComposerRector;
-use Ssch\TYPO3Rector\FileProcessor\TypoScript\Rector\v10\v0\ExtbasePersistenceTypoScriptRector;
+// not found with latest version of ssch/typo3-rector
+//use Ssch\TYPO3Rector\FileProcessor\TypoScript\Rector\v10\v0\ExtbasePersistenceTypoScriptRector;
 use Ssch\TYPO3Rector\FileProcessor\TypoScript\Rector\v9\v0\FileIncludeToImportStatementTypoScriptRector;
-use Ssch\TYPO3Rector\Rector\General\ExtEmConfRector;
+use Ssch\TYPO3Rector\CodeQuality\General\ExtEmConfRector;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 
+/**
+ * TYPO3 >= v12
+ * PHP >= 8.1
+ *
+ * Use rector:
+ * composer require ssch/typo3-rector:^2.6 rector/rector:^1.2 --dev
+ * 
+ *
+ */
 return static function (RectorConfig $rectorConfig): void {
 
     // If you want to override the number of spaces for your typoscript files you can define it here, the default value is 4
@@ -27,10 +37,10 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
         SetList::CODE_QUALITY,
         SetList::CODING_STYLE,
-        LevelSetList::UP_TO_PHP_74,
-        DowngradeLevelSetList::DOWN_TO_PHP_74,
+        LevelSetList::UP_TO_PHP_81,
+        DowngradeLevelSetList::DOWN_TO_PHP_81,
         SetList::TYPE_DECLARATION,
-        Typo3LevelSetList::UP_TO_TYPO3_11,
+        Typo3LevelSetList::UP_TO_TYPO3_12,
     ]);
 
     $rectorConfig->parallel(120, 5);
@@ -52,7 +62,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->importShortClasses(false);
 
     // Define your target version which you want to support
-    $rectorConfig->phpVersion(PhpVersion::PHP_74);
+    $rectorConfig->phpVersion(PhpVersion::PHP_81);
 
     // If you only want to process one/some TYPO3 extension(s), you can specify its path(s) here.
     // If you use the option --config change __DIR__ to getcwd()
@@ -96,12 +106,16 @@ return static function (RectorConfig $rectorConfig): void {
     // Rewrite your extbase persistence class mapping from typoscript into php according to official docs.
     // This processor will create a summarized file with all of the typoscript rewrites combined into a single file.
     // The filename can be passed as argument, "Configuration_Extbase_Persistence_Classes.php" is default.
+
+    // not found with latest version of ssch/typo3-rector
+    /*
     $rectorConfig->ruleWithConfiguration(
         ExtbasePersistenceTypoScriptRector::class,
         [
             ExtbasePersistenceTypoScriptRector::FILENAME => 'Configuration_Extbase_Persistence_Classes.php',
         ]
     );
+    */
 
     // Add some general TYPO3 rules
 #    $rectorConfig->rule(ConvertImplicitVariablesToExplicitGlobalsRector::class);
@@ -109,7 +123,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(
         ExtEmConfRector::class,
         [
-            ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '11.5.0-12.4.99',
+            ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '12.4.0-12.4.99',
             ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => [
                 'dependencies',
                 'conflicts',


### PR DESCRIPTION
rector did not run without errors, but also older packages are used. I updated the rector packages. Before making larger changes it might also be helpful to add GitHub ci to also execute phpstan automatically (is already in extension, did not check if this works for current version).


----

Install newer packages:

`composer require ssch/typo3-rector:^2.6 rector/rector:^1.2 --dev`
    
    Adapt rector.php for
    
 - minimum PHP 8.1
 - minimum TYPO3 v12

------

Apply rector rules
    
    `composer fix:php:rector`



