### PR TITLE
[TASK] Allow array values in user array

### DIFF
--- a/Classes/Authentication/SamlAuthService.php
+++ b/Classes/Authentication/SamlAuthService.php
@@ -397,7 +397,7 @@ class SamlAuthService extends AbstractAuthenticationService
         // Add values from SSO provider
         foreach ($samlAttributes as $attributeName => $attributeValues) {
             if (isset($transformationArr[$attributeName])) {
-                $userArr[$transformationArr[$attributeName]] = $attributeValues[0];
+                $userArr[$transformationArr[$attributeName]] = count($attributeValues) === 1 ? $attributeValues[0] : $attributeValues;
             }
         }
 


### PR DESCRIPTION
The current functionality defaults to the first subvalue in case of array values. Which is a fine default imo. However, sometimes we need access to the entire array. For example if a user has multiple usergroups assigned in AD, and we want to implement a custom mapping via the provided EventListener.

This commit changes the behaviour so the user array reflects the entire array, if there is more than one value in it. Otherwise the behaviour remains the same.